### PR TITLE
change some border-radii to 5px

### DIFF
--- a/Heatmap/Heatmap/Heatmap.css
+++ b/Heatmap/Heatmap/Heatmap.css
@@ -160,7 +160,7 @@
     background-color: var(--hover-background-color);
 	color: rgb(240, 240, 240) !important;
     padding: 5px;
-    border-radius: 3px;
+    border-radius: 5px;
     font-size: 12px;
     font-weight: normal;
     width: max-content;

--- a/Heatmap/heatmap3.css
+++ b/Heatmap/heatmap3.css
@@ -4,7 +4,7 @@
 */
 #heatmap {
     background-color: var(--background-color);
-    border-radius: 3px;
+    border-radius: 5px;
     padding: 10px 0;
     color: var(--color);
     --radical-color: #00aaff;
@@ -95,7 +95,7 @@
 #heatmap #popper {
     background-color: rgba(0, 0, 0, 0.9);
     width: fit-content;
-    border-radius: 3px;
+    border-radius: 5px;
     display: none;
     position: absolute;
     left: 50vw;


### PR DESCRIPTION
I noticed that most of the elements on the dashboard have a border radius of 5px, but the heatmap uses 3px (the same that kanji and radicals use). This branch fixes this inconsistency.